### PR TITLE
chore: indent size use 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,6 @@ module.exports = {
   },
   print (val) {
     const removedServerRenderedText = val.replace(/ data-server-rendered="true"/, '')
-    return beautify(removedServerRenderedText, { indent_size: 4 })
+    return beautify(removedServerRenderedText, { indent_size: 2 })
   }
 }


### PR DESCRIPTION
```js
expect(wrapper.vm.$el).toMatchSnapshot();  // indent size is 2
expect(wrapper.html()).toMatchSnapshot();
```