### PR TITLE
Hotfix: Ensure that recieved is not null | undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const beautify = require('pretty')
 
-const isHtmlString = received => typeof received === 'string' && received[0] === '<'
+const isHtmlString = received => received && typeof received === 'string' && received[0] === '<'
 const isVueWrapper = received => (
+  recieved &&
   typeof received === 'object' &&
   typeof received.isVueInstance === 'function'
 )


### PR DESCRIPTION
- Ensure that `recieved` property is not `null` or `undefined`
- Currently if this is the case then it breaks, as `recieved[0]` && `recieved.isVueInstance` is not executable