### PR TITLE
fix: add compatibility with @vue/test-utils@2 and vue3

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const isHtmlString = received => received && typeof received === 'string' && rec
 const isVueWrapper = received => (
   received &&
   typeof received === 'object' &&
-  typeof received.isVueInstance === 'function'
+  typeof received.html === 'function'
 )
 const removeServerRenderedText = html => html.replace(/ data-server-rendered="true"/, '')
 // [-\w]+ will catch 1 or more instances of a-z, A-Z, 0-9, hyphen (-), or underscore (_)


### PR DESCRIPTION
As described on https://github.com/eddyerburgh/jest-serializer-vue/issues/49#issuecomment-1316950926, closes https://github.com/eddyerburgh/jest-serializer-vue/issues/49

It doesn't work currently, because `isVueInstance` property [was already deprecated](https://v1.test-utils.vuejs.org/api/wrapper/isVueInstance.html#isvueinstance) in `@vue/test-utils@1` and as such it does not exist in v2 which is mandatory for vue3 app. That property is used to assert if the input is a `@vue/test-utils` wrapper. The fix was to replace it with `html` function check, since we actually call it a few lines bellow.


```diff
 const isVueWrapper = received => ( 
   received && 
   typeof received === 'object' && 
-   typeof received.isVueInstance === 'function' 
+   typeof received.html === 'function' 
```

https://github.com/eddyerburgh/jest-serializer-vue/blob/600b2c0e68e4a15c113d22beb10d706947e7409a/index.js#L4-L7

### Notes
- I could have included vue3 assertions, but the only way I could setup this project was by using `node@8` which is too far behind to allow installation of vue3 which requires the minimum node version to be `10`
- Making tests isomorphic (run through both vue2 and vue3) requires a bit of work and would also require me to fix the node version issues (which I don't have the time ATM). Usually we go with `vue-demi` or use the `vuelidate` strategy — a [swap-vue.js](https://github.com/vuelidate/vuelidate/blob/c17ad8927417c71378099c06ec914b4692c4c521/scripts/swap-vue.js) script combined with [aliased version packages](https://classic.yarnpkg.com/lang/en/docs/cli/add/#toc-yarn-add-alias).