### PR TITLE
feat: added typescript support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+export function test(received: any): boolean;
+export function print(val: unknown): string;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "A jest serializer for Vue snapshots",
   "version": "3.1.0",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
if you want to use the serializer in a typescript setup file like `setup.jest.ts` an error occurs which says that no type definitions are found

this pr adds the `index.d.ts` to the package which includes the the type definitions for this package